### PR TITLE
Do not fail on bad urls

### DIFF
--- a/lib/rawler/crawler.rb
+++ b/lib/rawler/crawler.rb
@@ -16,7 +16,7 @@ module Rawler
       response = Rawler::Request.get(url)
       
       doc = Nokogiri::HTML(response.body)
-      doc.css('a').map { |a| absolute_url(a['href']) }.select { |url| valid_url?(url) }
+      doc.css('a').map { |a| a['href'] }.select { |url| valid_url?(url) }.map { |url| absolute_url(url) }
     rescue Errno::ECONNREFUSED
       write("Couldn't connect to #{url}")
       []
@@ -45,8 +45,12 @@ module Rawler
     
     def valid_url?(url)
       scheme = URI.parse(url).scheme
-
       ['http', 'https'].include?(scheme)
+	  
+    rescue URI::InvalidURIError
+      write("Invalid url - '#{url}'")
+      false
+
     end
   
   end


### PR DESCRIPTION
if a site contains an invalid url (e.g. with an underscore in the domain name) the crawler should not fail.
