### PR TITLE
Sync output

### DIFF
--- a/lib/rawler/base.rb
+++ b/lib/rawler/base.rb
@@ -18,6 +18,7 @@ module Rawler
       @responses = {}
 
       Rawler.url      = URI.escape(url)
+      output.sync     = true
       Rawler.output   = Logger.new(output)
       Rawler.username = options[:username]
       Rawler.password = options[:password]


### PR DESCRIPTION
Hi,

I've updated logging feature to sync every time logger gets a message (needed by output redirection).

I need this when I try to redirect output of rawler to local file ("rawler http://example.com/ --wait 1 > /tmp/rawler_results.log" and then see it with "tail -f" command.
