### PR TITLE
Don't prepend https uris with http

### DIFF
--- a/lib/rawler.rb
+++ b/lib/rawler.rb
@@ -19,7 +19,7 @@ module Rawler
   def self.url=(url)
     url.strip!
 
-    if (url =~ /http:\/\//) != 0
+    if (url =~ /http[s]?:\/\//) != 0
       url = 'http://' + url
     end
 

--- a/spec/lib/rawler_spec.rb
+++ b/spec/lib/rawler_spec.rb
@@ -20,6 +20,27 @@ describe Rawler::Base do
       Rawler::Base.new(original, output)
       Rawler.url.should == expected
     end
+    
+    it "should auto prepend http" do
+      original = 'example.com'
+      expected = 'http://example.com'
+      Rawler::Base.new(original, output)
+      Rawler.url.should == expected
+    end
+    
+    it "should not auto prepend http when already http" do
+      original = 'http://example.com'
+      expected = 'http://example.com'
+      Rawler::Base.new(original, output)
+      Rawler.url.should == expected
+    end
+    
+    it "should not auto prepend http when https" do
+      original = 'https://example.com'
+      expected = 'https://example.com'
+      Rawler::Base.new(original, output)
+      Rawler.url.should == expected
+    end
   end
   
   describe "validate_links" do


### PR DESCRIPTION
A small change to keep rawler from prepending http to uris that already specified to be https
