### PR TITLE
crawler: Properly handle invalid (e.g. obfuscated) mailto urls.

### DIFF
--- a/lib/rawler/crawler.rb
+++ b/lib/rawler/crawler.rb
@@ -55,7 +55,7 @@ module Rawler
       else
         URI.parse(url).merge(path).to_s
       end
-    rescue URI::InvalidURIError
+    rescue URI::InvalidURIError, URI::InvalidComponentError
       write("Invalid url: #{path} - Called from: #{url}")
       nil
     end

--- a/spec/lib/rawler/crawler_spec.rb
+++ b/spec/lib/rawler/crawler_spec.rb
@@ -306,5 +306,20 @@ describe Rawler::Crawler do
       crawler.links.should == []
     end
   end
-  
+
+  context "invalid mailto" do
+    let(:content) { '<a href="mailto:obfuscated(at)example(dot)com">foo</a>' }
+    let(:url)     { 'http://example.com' }
+    let(:crawler) { Rawler::Crawler.new(url) }
+
+    before(:each) do
+      register(url, content)
+    end
+
+    it "should notify about the invalid url" do
+      output.should_receive(:error).with('Invalid url: mailto:obfuscated(at)example(dot)com - Called from: http://example.com')
+      crawler.links.should == []
+    end
+  end
+
 end


### PR DESCRIPTION
The crawler would previously raise exception upon hitting invalid (e.g. obfuscated) mailto urls. This patch remedies that.
