### PR TITLE
Add --logfile option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Rawler will only parse pages with content type 'text/html', but it will check fo
         --password, -p <s>:   HTT Basic Password
             --wait, -w <f>:   Seconds to wait between requests, may be fractional e.g. '1.5' (default: 3.0)
                  --log, -l:   Log results to file rawler_log.txt
+         --logfile, -o <s>:   Specify logfile, implies --log (default: rawler_log.txt)
+                 --css, -c:   Check CSS links
              --version, -v:   Print version and exit
                 --help, -h:   Show this message
 

--- a/bin/rawler
+++ b/bin/rawler
@@ -17,7 +17,8 @@ EOS
   opt :username, "HTT Basic Username", :type => :string
   opt :password, "HTT Basic Password", :type => :string
   opt :wait, "Seconds to wait between requests, may be fractional e.g. '1.5'", :type => :float, :default => 3.0
-  opt :log, "Log results to file rawler_log.txt", :type => :boolean, :default => false
+  opt :log, "Log results to file #{Rawler::Base::DEFAULT_LOGFILE}", :type => :boolean, :default => false
+  opt :logfile, "Specify logfile, implies --log", :type => :string, :default => Rawler::Base::DEFAULT_LOGFILE
   opt :css, "Check CSS links", :type => :boolean, :default => false
 end
 

--- a/lib/rawler.rb
+++ b/lib/rawler.rb
@@ -10,7 +10,7 @@ module Rawler
   mattr_accessor :url
   mattr_accessor :wait
   mattr_accessor :username, :password
-  mattr_accessor :log
+  mattr_accessor :log, :logfile
   mattr_accessor :css
 
   autoload :Base, "rawler/base"

--- a/lib/rawler/base.rb
+++ b/lib/rawler/base.rb
@@ -1,6 +1,8 @@
 module Rawler
   class Base
 
+    DEFAULT_LOGFILE = "rawler_log.txt"
+
     attr_accessor :responses
 
     def initialize(url, output, options={})
@@ -12,9 +14,13 @@ module Rawler
       Rawler.username = options[:username]
       Rawler.password = options[:password]
       Rawler.wait     = options[:wait]
-      Rawler.log      = options[:log]
       Rawler.css      = options[:css]
-      @logfile = File.new("rawler_log.txt", "w") if Rawler.log
+
+      # Using a custom logfile implies logging.
+      Rawler.logfile  = options[:logfile] || DEFAULT_LOGFILE
+      Rawler.log      = options[:log] || Rawler.logfile != DEFAULT_LOGFILE
+
+      @logfile = File.new(Rawler.logfile, "w") if Rawler.log
     end
 
     def validate

--- a/spec/lib/rawler_spec.rb
+++ b/spec/lib/rawler_spec.rb
@@ -12,6 +12,40 @@ describe Rawler::Base do
     register('http://example.com', site)
   end
 
+  describe "logfile" do
+    it "should have default value" do
+      url = 'http://example.com'
+
+      Rawler::Base.new(url, output)
+      Rawler.logfile.should == Rawler::Base::DEFAULT_LOGFILE
+    end
+
+    it "should honor logfile option" do
+      url = 'http://example.com'
+      logfile = 'custom_logfile'.freeze
+
+      Rawler::Base.new(url, output, :logfile => logfile)
+      Rawler.logfile.should == logfile
+    end
+  end
+
+  describe "log" do
+    it "should be turned off by default" do
+      url = 'http://example.com'
+
+      Rawler::Base.new(url, output)
+      Rawler.log.should == false
+    end
+
+    it "should be turned on when assigning custom logfile" do
+      url = 'http://example.com'
+      logfile = 'custom_logfile'
+
+      Rawler::Base.new(url, output, :logfile => logfile)
+      Rawler.log.should == true
+    end
+  end
+
   describe "url encoding" do
     it "should encode url" do
       original = 'http://example.com/写程序容易出现的几个不好的地方'


### PR DESCRIPTION
Allows specifying which logfile to write to. Assigning a custom logfile
implies turning on logging.

(Logfile could perhaps have been assigned via --log=filename but trollop
doesn't support boolean trigger with optional string, so a separate
option is used instead.)
