### PR TITLE
rawler/base: Properly handle circular redirections.

### DIFF
--- a/lib/rawler/base.rb
+++ b/lib/rawler/base.rb
@@ -55,9 +55,11 @@ module Rawler
     def add_status_code(link, from_url)
       response = Rawler::Request.get(link)
 
-      validate_page(response['Location'], from_url) if response['Location']
       record_response(response.code, link, from_url, response['Location'])
       responses[link] = { :status => response.code.to_i }
+
+      validate_page(response['Location'], from_url) if response['Location']
+
     rescue Errno::ECONNREFUSED
       error("Connection refused - #{link} - Called from: #{from_url}")
     rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, Errno::ETIMEDOUT,

--- a/spec/lib/rawler_spec.rb
+++ b/spec/lib/rawler_spec.rb
@@ -95,6 +95,15 @@ describe Rawler::Base do
       rawler.validate
     end
 
+    it "should handle circular redirections" do
+      register('http://example.com', '<a href="/foo">foo</a>')
+      register('http://example.com/foo', '', 301, :location => 'http://example.com/foo')
+
+      output.should_receive(:warn).with('301 - http://example.com/foo - Called from: http://example.com - Following redirection to: http://example.com/foo')
+
+      rawler.validate
+    end
+
   end
   
   describe "get_status_code" do


### PR DESCRIPTION
A url redirecting must be recorded as parsed before doing the redirect
in order to prevent possible infinite loops.
