### PR TITLE
Added Option to crawl URLs which include the start url

### DIFF
--- a/bin/rawler
+++ b/bin/rawler
@@ -22,6 +22,7 @@ EOS
   opt :css, "Check CSS links", :type => :boolean, :default => false
   opt :skip, "Skip URLS that match a pattern", :type => :string
   opt :iskip, "Skip URLS that match a case insensitive pattern", :type => :string
+  opt :local, "Restrict to the given URL and below", :type => :boolean, :default => false
 end
 
 

--- a/lib/rawler.rb
+++ b/lib/rawler.rb
@@ -13,6 +13,7 @@ module Rawler
   mattr_accessor :log, :logfile
   mattr_accessor :css
   mattr_accessor :skip_url_pattern
+  mattr_accessor :local
 
   autoload :Base, "rawler/base"
   autoload :Crawler, "rawler/crawler"

--- a/lib/rawler/base.rb
+++ b/lib/rawler/base.rb
@@ -15,6 +15,8 @@ module Rawler
       Rawler.password = options[:password]
       Rawler.wait     = options[:wait]
       Rawler.css      = options[:css]
+      
+      Rawler.local    = options[:local]
 
       Rawler.set_skip_pattern(options[:skip], false) unless options[:skip].nil?
       Rawler.set_skip_pattern(options[:iskip], true) unless options[:iskip].nil?

--- a/lib/rawler/crawler.rb
+++ b/lib/rawler/crawler.rb
@@ -91,6 +91,8 @@ module Rawler
       scheme = URI.parse(url).scheme
       if url =~ Rawler.skip_url_pattern
         false
+      elsif Rawler.local and not url.include?(Rawler.url)
+        false
       elsif ['http', 'https'].include?(scheme)
         true
       else

--- a/spec/lib/rawler/crawler_spec.rb
+++ b/spec/lib/rawler/crawler_spec.rb
@@ -223,6 +223,30 @@ describe Rawler::Crawler do
       end
     end
 
+    context "non-local site should be omitted when local flag is used" do
+      let(:url)     { 'http://example.com/' }
+      let(:crawler) { Rawler::Crawler.new(url) }
+      let(:content) { "<a href=\"http://example.com/page1/\">foo</a><a href=\"http://example.org/page2\">foo</a>" }
+    
+      before(:each) do
+        Rawler::local = true
+        register(url, content)
+      end
+    
+      it "should return one link" do
+        crawler.links.length.should eql(1)
+      end
+
+      it "should not report that it's skipping" do
+        crawler.should_not_receive(:write)
+        crawler.links
+      end
+
+      after(:each) do
+        Rawler::local = false
+      end
+    end
+  
   end
 
   context "content type" do


### PR DESCRIPTION
The option --local (short -a) should crawl URLs which start the given
starting point URL. All other links should be skipped.
