### PR TITLE
clean up require paths

### DIFF
--- a/bin/rawler
+++ b/bin/rawler
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'rawler'
+require_relative '../lib/rawler'
 require File.join(File.dirname(__FILE__), '..', '/vendor/lib-trollop.rb')
 
 opts = Trollop::options do

--- a/lib/rawler.rb
+++ b/lib/rawler.rb
@@ -2,9 +2,10 @@ require 'rubygems'
 require 'net/https'
 require 'nokogiri'
 require 'logger'
-require 'rawler/core_extensions'
+require_relative 'rawler/core_extensions'
 module Rawler
-  VERSION = "#{File.read(File.expand_path(File.dirname(__FILE__)) + '/../VERSION')}"
+  dir = File.dirname(__FILE__)
+  VERSION = File.read(File.join(dir, '..', 'VERSION'))
 
   mattr_accessor :output
   mattr_accessor :url
@@ -15,9 +16,9 @@ module Rawler
   mattr_accessor :include_url_pattern
   mattr_accessor :skip_url_pattern
 
-  autoload :Base, "rawler/base"
-  autoload :Crawler, "rawler/crawler"
-  autoload :Request, "rawler/request"
+  autoload :Base, File.join(dir, 'rawler', 'base')
+  autoload :Crawler, File.join(dir, 'rawler', 'crawler')
+  autoload :Request, File.join(dir, 'rawler', 'request')
 
   def self.url=(url)
     url.strip!

--- a/lib/rawler/core_extensions.rb
+++ b/lib/rawler/core_extensions.rb
@@ -1,1 +1,1 @@
-require 'rawler/core_extensions/module'
+require_relative 'core_extensions/module'

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+require 'spec_helper'
 
 describe Rawler do
 

--- a/spec/lib/rawler/crawler_spec.rb
+++ b/spec/lib/rawler/crawler_spec.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require File.dirname(__FILE__) + '/../../spec_helper.rb'
+require 'spec_helper'
 
 describe Rawler::Crawler do
 

--- a/spec/lib/rawler_spec.rb
+++ b/spec/lib/rawler_spec.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+require 'spec_helper'
 
 describe Rawler::Base do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,7 @@ module Kernel
 end
 
 
-$:.unshift(File.dirname(__FILE__) + '/../lib')
-require 'rawler'
+require_relative '../lib/rawler'
 require 'fakeweb'
 
 FakeWeb.allow_net_connect = false


### PR DESCRIPTION
- use require_relative instead of needing to grab the directory of the current file
- use the full paths of files for autoloading, so that the files from the installed gem aren't loaded accidentally during development
- spec_helper can simply be `require`d, since the spec directory is added to the load path by rspec
