### PR TITLE
Rawler returns number of errors as exit code

### DIFF
--- a/bin/rawler
+++ b/bin/rawler
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative '../lib/rawler'
-require File.join(File.dirname(__FILE__), '..', '/vendor/lib-trollop.rb')
+require_relative '../vendor/lib-trollop'
 
 opts = Trollop::options do
   version "rawler #{Rawler::VERSION} (c) 2011 Oscar Del Ben"
@@ -39,4 +39,7 @@ else
   end
 end
 
-Rawler::Base.new(domain, $stdout, opts).validate
+rawler = Rawler::Base.new(domain, $stdout, opts)
+rawler.validate
+
+exit(rawler.errors.count)

--- a/lib/rawler/base.rb
+++ b/lib/rawler/base.rb
@@ -37,6 +37,12 @@ module Rawler
       @logfile.close if Rawler.log
     end
 
+    def errors
+      @responses.reject{ |link, response|
+        (100..399).include?(response[:status].to_i)
+      }
+    end
+
     private
 
     def validate_links_in_page(page)

--- a/spec/lib/rawler_spec.rb
+++ b/spec/lib/rawler_spec.rb
@@ -282,9 +282,35 @@ describe Rawler::Base do
         output.should_receive(:error).with("Unknown code #{code} - #{link} - Called from: #{from}")
         rawler.send(:record_response, code, link, from)
       end
-    end
-    
+    end    
   end
+
+  describe "error introspection" do
+    context "no error codes occured" do
+      before do
+        rawler.responses["http://example.com/"]    = { :status => 100 }
+        rawler.responses["http://example.com/foo"] = { :status => 200 }
+        rawler.responses["http://example.com/bar"] = { :status => 300 }
+      end
+
+      it "should give all occurring errors" do
+        rawler.errors.should be_empty
+      end
+    end
+
+    context "error codes occured" do
+      before do
+        rawler.responses["http://example.com/"]    = { :status => 100 }
+        rawler.responses["http://example.com/foo"] = { :status => 400 }
+        rawler.responses["http://example.com/bar"] = { :status => 500 }
+      end
+
+      it "should give all occurring errors" do
+        rawler.errors.count.should eq 2
+      end
+    end
+  end
+
   
   
   private


### PR DESCRIPTION
With a proper exit code, rawler can now more easily be set up in automated
environments like continues integration systems and ensure the link
integrity of static pages.